### PR TITLE
Convert field elements to bytes

### DIFF
--- a/poseidon2.nim
+++ b/poseidon2.nim
@@ -6,6 +6,8 @@ import poseidon2/types
 import poseidon2/roundconst
 import poseidon2/io
 
+export toBytes
+
 #-------------------------------------------------------------------------------
 
 const zero : F = getZero()

--- a/poseidon2.nim
+++ b/poseidon2.nim
@@ -98,4 +98,4 @@ func merkleRoot*(xs: openArray[F]) : F =
     return merkleRoot(ys)
 
 func merkleRoot*(bytes: openArray[byte]): F =
-  merkleRoot(seq[F].unmarshal(bytes))
+  merkleRoot(seq[F].fromBytes(bytes))

--- a/poseidon2/io.nim
+++ b/poseidon2/io.nim
@@ -1,6 +1,7 @@
 import ./types
 import constantine/math/arithmetic
 import constantine/math/io/io_bigints
+import constantine/math/config/curves
 
 func unmarshal*(_: type F, bytes: openArray[byte]): F =
   ## Converts bytes into a field element. The byte array is interpreted as a
@@ -25,3 +26,9 @@ func unmarshal*(_: type seq[F], bytes: openArray[byte]): seq[F] =
     elements.add(element)
     chunkStart += chunkLen
   return elements
+
+func marshal*(element: F): array[32, byte] =
+  ## Converts a field element into its canonical representation in little-endian
+  ## byte order. Uses at most 254 bits, the remaining 6 most-significant bits
+  ## are set to 0.
+  assert marshal(result, element.toBig(), littleEndian)

--- a/poseidon2/io.nim
+++ b/poseidon2/io.nim
@@ -3,7 +3,7 @@ import constantine/math/arithmetic
 import constantine/math/io/io_bigints
 import constantine/math/config/curves
 
-func unmarshal*(_: type F, bytes: openArray[byte]): F =
+func fromBytes*(_: type F, bytes: openArray[byte]): F =
   ## Converts bytes into a field element. The byte array is interpreted as a
   ## canonical little-endian big integer. The array should be of length 31 bytes
   ## or less to ensure that it fits in a field of 254 bits. The remaining
@@ -14,20 +14,20 @@ func unmarshal*(_: type F, bytes: openArray[byte]): F =
   let bigint = B.unmarshal(padded, littleEndian)
   return F.fromBig(bigint)
 
-func unmarshal*(_: type seq[F], bytes: openArray[byte]): seq[F] =
+func fromBytes*(_: type seq[F], bytes: openArray[byte]): seq[F] =
   ## Converts bytes into field elements. The byte array is converted 31 bytes at
-  ## a time with the `F.unmarshal()` function.
+  ## a time with the `F.fromBytes()` function.
   const chunkLen = 31
   var elements: seq[F]
   var chunkStart = 0
   while chunkStart < bytes.len:
     let chunkEnd = min(chunkStart + 31, bytes.len)
-    let element = F.unmarshal(bytes.toOpenArray(chunkStart, chunkEnd - 1))
+    let element = F.fromBytes(bytes.toOpenArray(chunkStart, chunkEnd - 1))
     elements.add(element)
     chunkStart += chunkLen
   return elements
 
-func marshal*(element: F): array[32, byte] =
+func toBytes*(element: F): array[32, byte] =
   ## Converts a field element into its canonical representation in little-endian
   ## byte order. Uses at most 254 bits, the remaining 6 most-significant bits
   ## are set to 0.

--- a/tests/poseidon2/testIo.nim
+++ b/tests/poseidon2/testIo.nim
@@ -5,20 +5,20 @@ import constantine/math/arithmetic
 import poseidon2/types
 import poseidon2/io
 
-suite "unmarshalling":
+suite "conversion to/from bytes":
 
   test "converts little endian bytes into field elements":
     let bytes = toSeq 1'u8..31'u8
     let paddedTo32 = bytes & @[0'u8] # most significant byte is not used
     let expected = F.fromBig(B.unmarshal(paddedTo32, littleEndian))
-    let unmarshalled = F.unmarshal(bytes)
+    let unmarshalled = F.fromBytes(bytes)
     check bool(unmarshalled == expected)
 
   test "pads little endian bytes to the right with 0's":
     let bytes = @[0x56'u8, 0x34, 0x12]
     let paddedTo32 = bytes & 0'u8.repeat(32 - bytes.len)
     let expected = F.fromBig(B.unmarshal(paddedTo32, littleEndian))
-    let unmarshalled = F.unmarshal(bytes)
+    let unmarshalled = F.fromBytes(bytes)
     check bool(unmarshalled == expected)
 
   test "converts every 31 bytes into a field element":
@@ -27,7 +27,7 @@ suite "unmarshalling":
     let expected1 = F.fromBig(B.unmarshal(padded[ 0..<31] & @[0'u8], littleEndian))
     let expected2 = F.fromBig(B.unmarshal(padded[31..<62] & @[0'u8], littleEndian))
     let expected3 = F.fromBig(B.unmarshal(padded[62..<93] & @[0'u8], littleEndian))
-    let elements = seq[F].unmarshal(bytes)
+    let elements = seq[F].fromBytes(bytes)
     check elements.len == 3
     check bool(elements[0] == expected1)
     check bool(elements[1] == expected2)
@@ -38,4 +38,4 @@ suite "unmarshalling":
     setMinusOne(element) # largest element in the field
     var expected: array[32, byte]
     marshal(expected, element.toBig(), littleEndian)
-    check element.marshal() == expected
+    check element.toBytes() == expected

--- a/tests/poseidon2/testIo.nim
+++ b/tests/poseidon2/testIo.nim
@@ -33,3 +33,9 @@ suite "unmarshalling":
     check bool(elements[1] == expected2)
     check bool(elements[2] == expected3)
 
+  test "converts field element into little-endian bytes":
+    var element: F
+    setMinusOne(element) # largest element in the field
+    var expected: array[32, byte]
+    marshal(expected, element.toBig(), littleEndian)
+    check element.marshal() == expected

--- a/tests/poseidon2/testPoseidon2.nim
+++ b/tests/poseidon2/testPoseidon2.nim
@@ -5,7 +5,7 @@ import std/sequtils
 import constantine/math/arithmetic
 import constantine/math/io/io_fields
 import constantine/math/io/io_bigints
-import constantine/math/config/curves
+import constantine/serialization/codecs
 
 import poseidon2/types
 import poseidon2
@@ -31,9 +31,14 @@ suite "poseidon2":
       xs.add( toF(i) )
 
     let root = merkleRoot(xs)
-    check root.toHex == "0x1eabbb64b76d5aecd393601c4a01878450e23f45fe8b2748bb63a615351b11d1"
+    check root.toHex(littleEndian) == "0xd1111b3515a663bb48278bfe453fe2508487014a1c6093d3ec5a6db764bbab1e"
 
   test "merkle root of bytes":
     let bytes = toSeq 1'u8..80'u8
     let root = merkleRoot(bytes)
-    check root.toHex == "0x2d2d6f27d20a9e5597e20a888a4deac0e0600f92f0b9691ace0fdfab2fc1f500"
+    check root.toHex(littleEndian) == "0x00f5c12fabdf0fce1a69b9f0920f60e0c0ea4d8a880ae297559e0ad2276f2d2d"
+
+  test "merkle root of bytes converted to bytes":
+    let bytes = toSeq 1'u8..80'u8
+    let rootAsBytes = merkleRoot(bytes).toBytes()
+    check rootAsBytes.toHex == "0x00f5c12fabdf0fce1a69b9f0920f60e0c0ea4d8a880ae297559e0ad2276f2d2d"


### PR DESCRIPTION
Allows a user of the library to create a merkle root of bytes, and store the result as bytes.

```nim
let digest = merkleRoot(someByteArray).toBytes()
```

Also renames the `unmarshal` funcs to `fromBytes`, for two reasons:
- to better distinguish them from the constantine functions
- they do not follow the convention that something  that is marshalled can be unmarshalled, because  they take in 31 bytes but produce 32 bytes