### PR TITLE
Keyed compress

### DIFF
--- a/poseidon2.nim
+++ b/poseidon2.nim
@@ -5,21 +5,15 @@ import poseidon2/types
 import poseidon2/permutation
 import poseidon2/io
 import poseidon2/sponge
+import poseidon2/compress
 
 export sponge
+export compress
 export toBytes
 export elements
 export types
 
 #-------------------------------------------------------------------------------
-
-# 2-to-1 compression
-func compress*(a, b : F) : F =
-  var x = a
-  var y = b
-  var z : F ; setZero(z)
-  permInplace(x, y, z)
-  return x
 
 func merkleRoot*(xs: openArray[F]) : F =
   let a = low(xs)

--- a/poseidon2/compress.nim
+++ b/poseidon2/compress.nim
@@ -1,0 +1,10 @@
+import ./types
+import ./permutation
+
+# 2-to-1 compression
+func compress*(a, b : F) : F =
+  var x = a
+  var y = b
+  var z : F = zero
+  permInplace(x, y, z)
+  return x

--- a/poseidon2/compress.nim
+++ b/poseidon2/compress.nim
@@ -2,9 +2,9 @@ import ./types
 import ./permutation
 
 # 2-to-1 compression
-func compress*(a, b : F) : F =
+func compress*(a, b : F, key = zero) : F =
   var x = a
   var y = b
-  var z : F = zero
+  var z = key
   permInplace(x, y, z)
   return x

--- a/tests/poseidon2/testCompress.nim
+++ b/tests/poseidon2/testCompress.nim
@@ -1,0 +1,15 @@
+import std/unittest
+import constantine/math/arithmetic
+import poseidon2/types
+import poseidon2/permutation
+import poseidon2/compress
+
+suite "compress":
+
+  test "uses permutation to compress two elements":
+    check bool(compress(1.toF, 2.toF) == (1.toF, 2.toF, 0.toF).perm[0])
+    check bool(compress(3.toF, 4.toF) == (3.toF, 4.toF, 0.toF).perm[0])
+
+  test "allows for keyed compression":
+    check bool(compress(1.toF, 2.toF, key=3.toF) == (1.toF, 2.toF, 3.toF).perm[0])
+    check bool(compress(4.toF, 5.toF, key=6.toF) == (4.toF, 5.toF, 6.toF).perm[0])

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -1,5 +1,6 @@
 import ./poseidon2/testPermutation
 import ./poseidon2/testSponge
+import ./poseidon2/testCompress
 import ./poseidon2/testPoseidon2
 import ./poseidon2/testIo
 import ./poseidon2/testReadme


### PR DESCRIPTION
Allows for additional information to be hashed when combining two field elements. Especially useful for adding information when constructing a Merkle tree.