### PR TITLE
Fix: add missing import

### DIFF
--- a/poseidon2/sponge.nim
+++ b/poseidon2/sponge.nim
@@ -1,5 +1,6 @@
 import ./types
 import ./permutation
+import ./io
 import constantine/math/io/io_fields
 import constantine/math/arithmetic
 


### PR DESCRIPTION
Fixes "attempting to call undeclared routine: 'elements'" when calling Sponge.digest from a project using the nimble package