### PR TITLE
Fix: workaround for "undeclared identifier: 'getCurveOrder'"

### DIFF
--- a/poseidon2.nim
+++ b/poseidon2.nim
@@ -13,3 +13,7 @@ export toBytes
 export toF
 export elements
 export types
+
+# workaround for "undeclared identifier: 'getCurveOrder'"
+import constantine/math/config/curves
+export curves


### PR DESCRIPTION
Calling `toF` in some cases lead to an error:

```
constantine\math\config\curves_prop_field_derived.nim(67, 5) Error: undeclared identifier: 'getCurveOrder'
```

This is a workaround, ensuring that getCurveOrder is defined wherever posedion2 is imported.