### PR TITLE
exports fromBytes from the library

### DIFF
--- a/poseidon2.nim
+++ b/poseidon2.nim
@@ -9,6 +9,7 @@ export sponge
 export compress
 export merkle
 export spongemerkle
+export fromBytes
 export toBytes
 export toF
 export elements


### PR DESCRIPTION
Exports `fromBytes` from the `nim-poseidon2` lib.

It is still a mystery how this is working in `nim-codex/master`:
https://github.com/codex-storage/nim-codex/blob/master/codex/merkletree/poseidon2.nim#L77
```nim
    leaves.mapIt( Poseidon2Hash.fromBytes(it) ))
```

Before the changes in [nim-codex#663](https://github.com/codex-storage/nim-codex/pull/663), `fromBytes` seemed to have been resolved correctly by `nim-poseidon/io`. However, with the changes in [nim-codex#663](https://github.com/codex-storage/nim-codex/pull/663), `fromBytes` could no longer be resolved. By exporting `fromBytes` from `nim-poseidon2`, the correct resolution is now happening.

Note that the base branch for this PR is the branch for #18.
